### PR TITLE
Fix API create / update bug

### DIFF
--- a/siivagunnerdb/siivagunnerdb/views.py
+++ b/siivagunnerdb/siivagunnerdb/views.py
@@ -53,14 +53,14 @@ class MultipleModelViewSet(ModelViewSet):
         Override GET serializer with modified fields parameter.
         """
         kwargs['fields'] = self.get_list_parameter('fields')
-        return self.serializer_class(*args, **kwargs)
+        return super().get_serializer(*args, **kwargs)
 
     def get_pagination_serializer(self, *args, **kwargs):
         """
         Override paginated GET serializer with modified fields parameter.
         """
         kwargs['fields'] = self.get_list_parameter('fields')
-        return self.pagination_serializer_class(*args, **kwargs)
+        return super().get_pagination_serializer(*args, **kwargs)
 
     def create(self, request, *args, **kwargs):
         """

--- a/siivagunnerdb/siivagunnerdb/youtube/videos/models.py
+++ b/siivagunnerdb/siivagunnerdb/youtube/videos/models.py
@@ -8,16 +8,6 @@ from siivagunnerdb.youtube.playlists.models import Playlist
 WikiStatus = models.TextChoices('WikiStatusChoice', 'Documented Undocumented')
 VideoStatus = models.TextChoices('VideoStatusChoice', 'Public Unlisted Unavailable Private Deleted')
 
-# All fields except contributors and playlists
-COMMON_VIDEO_FIELDS = (
-    'id', 'publishedAt', 'title', 'description', 'thumbnails', 'channelTitle',
-    'tags', 'categoryId', 'liveBroadcastContent', 'defaultLanguage',
-    'localized', 'defaultAudioLanguage', 'duration', 'dimension', 'definition',
-    'caption', 'licensedContent', 'regionRestriction', 'contentRating',
-    'projection', 'viewCount', 'likeCount', 'dislikeCount', 'favoriteCount',
-    'commentCount', 'channel', 'wikiStatus', 'videoStatus'
-)
-
 
 class Video(StandardModel):
     id = models.CharField(primary_key=True, max_length=11)

--- a/siivagunnerdb/siivagunnerdb/youtube/videos/serializers.py
+++ b/siivagunnerdb/siivagunnerdb/youtube/videos/serializers.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 from siivagunnerdb.serializers import LoggedModelSerializer
-from .models import Video, COMMON_VIDEO_FIELDS
+from .models import Video
 
 
 class VideoSerializer(LoggedModelSerializer):
     class Meta:
         model = Video
-        fields = COMMON_VIDEO_FIELDS
+        fields = '__all__'

--- a/siivagunnerdb/siivagunnerdb/youtube/videos/views.py
+++ b/siivagunnerdb/siivagunnerdb/youtube/videos/views.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from siivagunnerdb.views import MultipleModelViewSet
 from urllib.parse import urlencode
 
-from .models import Video, COMMON_VIDEO_FIELDS
+from .models import Video
 from .serializers import VideoSerializer
 
 
@@ -224,7 +224,7 @@ class VideoViewSet(MultipleModelViewSet):
     """
     API endpoint that allows videos to be viewed or edited.
     """
-    queryset = Video.objects.select_related('channel')
+    queryset = Video.objects.all()
     serializer_class = VideoSerializer
-    filterset_fields = COMMON_VIDEO_FIELDS
-    ordering_fields = COMMON_VIDEO_FIELDS
+    filterset_fields = '__all__'
+    ordering_fields = '__all__'


### PR DESCRIPTION
The bug occurred during POST and PUT requests because the wrong method was being returned in two overriding serializer getters.