### PR TITLE
Add CSRF_TRUSTED_ORIGINS to settings_core.py

### DIFF
--- a/siivagunnerdb/siivagunnerdb/settings_core.py
+++ b/siivagunnerdb/siivagunnerdb/settings_core.py
@@ -109,6 +109,12 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Trusted sites for POST requests with CSRF tokens
+CSRF_TRUSTED_ORIGINS = [
+    'https://siivagunnerdatabase.net',
+    'https://dev.siivagunnerdatabase.net',
+]
+
 # Internationalization
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'


### PR DESCRIPTION
Fix for 403 response errors resulting from Django upgrade